### PR TITLE
By yanniboi: Update dashboard tabs ajax to use .active instead of .is-active.

### DIFF
--- a/contacts_theme.info.yml
+++ b/contacts_theme.info.yml
@@ -28,3 +28,5 @@ libraries-extend:
     - contacts_theme/listings
   contacts/action.group:
     - contacts_theme/action.group
+  contacts/tabs:
+    - contacts_theme/tabs

--- a/contacts_theme.libraries.yml
+++ b/contacts_theme.libraries.yml
@@ -23,3 +23,8 @@ action.group:
       css/contacts/action-group.css: {}
   js:
     js/dropdown.js: {}
+
+# AJAXed tabs with history (if supported).
+tabs:
+  js:
+    js/tabs.js: {}

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * Contact Dashboard ajax navigation.
+ */
+
+(function ($, Drupal) {
+
+  'use strict';
+
+  var historySupport = !!(window.history && history.pushState);
+
+  /**
+   * Fill out the tab with the response contents.
+   *
+   * @param {Drupal.Ajax} ajax
+   *   {@link Drupal.Ajax} object created by {@link Drupal.ajax}.
+   * @param {object} response
+   *   JSON response from the Ajax request.
+   * @param {number} [status]
+   *   XMLHttpRequest status.
+   */
+  Drupal.AjaxCommands.prototype.contactsTab = function (ajax, response, status) {
+    if (response.activeTab) {
+      $('.contacts-ajax-tabs .active').removeClass('active');
+      $('.contacts-ajax-tabs .' + response.activeTab).find('a').andSelf().addClass('active');
+    }
+
+    if (response.url && historySupport) {
+      var current_url = document.location.pathname + document.location.search;
+      if (current_url !== response.url) {
+        history.pushState({}, '', response.url);
+      }
+    }
+  };
+
+  // If supported, set the browser back/forward buttons up to trigger AJAX
+  // requests that update the tabs.
+  if (historySupport) {
+    $(window).on('popstate', function (e) {
+      // Look for an ajax link with this url.
+      $('.contacts-ajax-tabs a.use-ajax[href="' + document.location.pathname + '"]').trigger('click');
+    });
+  }
+
+})(jQuery, Drupal);


### PR DESCRIPTION
Currently when selecting a dashboard tab the ajax update adds the 'is-active' class to the newly active tab. This needs to however be the 'active' class for bootstrap.

There may be a better way of doing this than replacing the whole ajax update, but this works.